### PR TITLE
Fixes #1: Add option to build with poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ By default, Pysa Action will use the default SAPP filters to filter its results.
 - You prefer to apply no filters to your Pysa results, because you would like to see all Pysa results
 - You prefer to filter Pysa results only using the SAPP filters you've written in `sapp-filters-directory`
 
+### `use-poetry`
+When set to `true`, Pysa Action will install poetry with the Python Package installer and use it to install dependencies.
+
+By default, it is set to `false` and the requirements file is used as a source of requirements to be installed by the Python Package Installer (pip).
+
 ## License
 
 Pysa Action is licensed under the MIT license.

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
   requirements-path:
     description: Path to requirements file, relative to `repo-directory`, to look for dependencies. Default will look for requirements.txt in the root of repo-directory
-    required: true
+    required: false
     default: "requirements.txt"
   use-nightly:
     description: Use nightly (unstable) version of Pysa
@@ -39,6 +39,11 @@ inputs:
     description: Use SAPP filters packaged with Pysa
     required: false
     default: true
+    type: boolean
+  use-poetry:
+    description: Use poetry to install dependencies
+    required: false
+    default: false
     type: boolean
 
 runs:
@@ -78,16 +83,22 @@ runs:
     - name: Install dependencies
       working-directory: ${{inputs.repo-directory}}
       run: |
-        if [ "$REQUIREMENTS_PATH" != '' ] && [ -f "$REQUIREMENTS_PATH" ]; then
-          pip install -r ${{inputs.requirements-path}}
+        if [ "$USE_POETRY" ]; then
+          pip install poetry
+          poetry install --no-root
         else
-          echo "Path $REPO_DIR/$REQUIREMENTS_PATH does not exist"
-          exit 1
+          if [ "$REQUIREMENTS_PATH" != '' ] && [ -f "$REQUIREMENTS_PATH" ]; then
+            pip install -r ${{inputs.requirements-path}}
+          else
+            echo "Path $REPO_DIR/$REQUIREMENTS_PATH does not exist"
+            exit 1
+          fi
         fi
       shell: bash
       env:
         REQUIREMENTS_PATH: ${{inputs.requirements-path}}
         REPO_DIR: ${{inputs.repo-directory}}
+        USE_POETRY: ${{inputs.use-poetry}}
 
     - name: Prepare SAPP filters directory
       run: |

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
     - name: Install dependencies
       working-directory: ${{inputs.repo-directory}}
       run: |
-        if [ "$USE_POETRY" ]; then
+        if [ "$USE_POETRY" = true ]; then
           pip install poetry
           poetry install --no-root
         else


### PR DESCRIPTION
Add option to install dependencies with poetry in the action.
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>

Poetry docs:
https://python-poetry.org/docs/#installing-with-pipx
https://python-poetry.org/docs/basic-usage/#installing-dependencies-only

Why `--no-root`: poetry installs projects as editable by default with `--no-root` we get the same behavior as pip install.

Fixes #1 