### PR TITLE
Remove submodule to use live version of pyre-check

### DIFF
--- a/.github/workflows/test_no_pyre_config.yml
+++ b/.github/workflows/test_no_pyre_config.yml
@@ -12,11 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
 
       - name: Prepare deliberately_vulnerable_flask_app
         run: |
+          git clone https://github.com/facebook/pyre-check test/pyre-check
           rm test/pyre-check/.pyre_configuration
 
       # For testing infer-types option

--- a/.github/workflows/test_with_pyre_config.yml
+++ b/.github/workflows/test_with_pyre_config.yml
@@ -12,17 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
 
-      - name: Create pyre config for deliberately_vulnerable_flask_app
+      # For delibrate_vulnerable_flask_app
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '>=3.6'
+
+      - name: Setup deliberately_vulnerable_flask_app
         run: |
-          rm test/pyre-check/.pyre_configuration
-          echo '{
-              "source_directories": ["."],
-              "search_path": "../../stubs",
-              "taint_models_path": "../../stubs"
-          }' > test/pyre-check/documentation/deliberately_vulnerable_flask_app/.pyre_configuration
+          git clone https://github.com/facebook/pyre-check test/pyre-check
+          (cd test/pyre-check/documentation/deliberately_vulnerable_flask_app/ && . ./setup.sh)
+          cat test/pyre-check/documentation/deliberately_vulnerable_flask_app/.pyre_configuration
 
       # For testing infer-types option
       - name: Delete existing type annotations in app.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/pyre-check"]
-	path = test/pyre-check
-	url = https://github.com/facebook/pyre-check.git


### PR DESCRIPTION
Previously we used a very old state of pyre-check repository as a submodule to run Github Actions against and test the action in this repository.

Currently, pyre-check has moved forward and current python module of pyre-check fails to detect issues based on the submodule. Also, since we want the action to be upto date with pyre-check it only makes sense to use git clone during the workflows instead of a submodule fixed on a particular reference.

Fixes the build error in the workflow

Demo:
https://github.com/abishekvashok/pysa-action/actions/runs/4542528482
https://github.com/abishekvashok/pysa-action/actions/runs/4542528481

The demo workflows fail as I don't have the token configured for uploading any SARIF files (it should pass in this PR and repository)

Also see this PR's workflows.

What to look in the newer workflows?
See that the sapp action runs successfully as opposed to that in main and see that both actions can find issues (as opposed to main in this repository)

Main workflow for reference: https://github.com/facebook/pysa-action/actions/runs/4534111680
