### PR TITLE
workflows: Bump version, fix warnings in actions

### DIFF
--- a/.github/workflows/test_no_pyre_config.yml
+++ b/.github/workflows/test_no_pyre_config.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/test_with_pyre_config.yml
+++ b/.github/workflows/test_with_pyre_config.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '>=3.6'
 
@@ -156,7 +156,7 @@ runs:
       shell: bash
 
     - name: Saving Pysa results for SAPP
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pysa-results
         path: ${{inputs.repo-directory}}/pysa-output


### PR DESCRIPTION
## Changes

- [test_no_pyre_config.yml: bump actions/checkout version to v3](https://github.com/facebook/pysa-action/commit/95ce0e96cb3ba5460f57020ca276a4fa832fb88c)
- [test_with_pyre_config.yml: bump actions/checkout version to v3](https://github.com/facebook/pysa-action/commit/fd0414ed04aeadc8aafd82d28c06ae1cc6a0e25a)
- [action.yml: bump workflows versions](https://github.com/facebook/pysa-action/commit/73386a674ed5350a772ef28cf197d85647278b9c) [Bump actions/setup-python version to v4, actions/upload-artifact to v3]

## Fixes

- This PR fixes the node deprecation warnings shown in Annotations in the workflow runs.