### PR TITLE
Update to newest version of github actions for python and artifact 

### DIFF
--- a/.github/workflows/test_no_pyre_config.yml
+++ b/.github/workflows/test_no_pyre_config.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare deliberately_vulnerable_flask_app
         run: |

--- a/.github/workflows/test_with_pyre_config.yml
+++ b/.github/workflows/test_with_pyre_config.yml
@@ -11,11 +11,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # For delibrate_vulnerable_flask_app
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '>=3.6'
 

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '>=3.6'
 
@@ -156,7 +156,7 @@ runs:
       shell: bash
 
     - name: Saving Pysa results for SAPP
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pysa-results
         path: ${{inputs.repo-directory}}/pysa-output


### PR DESCRIPTION
python and artifact-upload

I've done the CLA.

The python action and the artifact-upload action versions that were being used were deprecated. This PR updates them to the latest version.